### PR TITLE
Move the case's strap wings up

### DIFF
--- a/hardware/case/case.scad
+++ b/hardware/case/case.scad
@@ -167,11 +167,13 @@ module case_top()
 				{
 					linear_extrude(height = 10.5)
 						case_top_shape();
-					translate([-5, 0, 0])
-						strap_wing();
-					translate([28, 0, 3.5])
-						rotate([0,180,0])
+					translate([-5, -2.15, 6])
+						scale([1, 0.57, 1])
 							strap_wing();
+					translate([28, -2.15, 9.5])
+						rotate([0,180,0])
+							scale([1, 0.57, 1])
+								strap_wing();
 				}
 				
 				translate([0, 0, -2])

--- a/hardware/case/case.scad
+++ b/hardware/case/case.scad
@@ -106,8 +106,6 @@ module strap_wing()
 		}
 		translate([-3,0,-1])
 			cube([20,75,7]);
-		translate([1,-3.5,-1])
-			cube([20,80,7]);
 	}
 }
 


### PR DESCRIPTION
The case's strap wings are currently too low - the thickness of the
straps will cause the case to lift up, while we want to keep pressure on
the arm so that light doesn't spill over from the LEDs into the
photodiodes.
    
This commit moves the strap up above the vents, and shortens the wings
so that they don't block the SPI connector hole.

This PR depends on https://github.com/CodethinkLabs/bloodlight-hardware/pull/4