### PR TITLE
Make the screws fit inside the case

### DIFF
--- a/hardware/case/case-parts.scad
+++ b/hardware/case/case-parts.scad
@@ -1,3 +1,12 @@
+// Model of an m2x6mm screw to check whether it fits
+module screw_m2()
+{
+	union()
+	{
+		cylinder(d=2, h=6, $fn=30);
+		cylinder(d1=3.8, d2=2, h=1.2, $fn=30);
+	}
+}
 
 // difference this into something to create the appropriate sized hole for
 // an m2 to pass through

--- a/hardware/case/case-parts.scad
+++ b/hardware/case/case-parts.scad
@@ -19,7 +19,7 @@ module passthrough_screw_hole_m2()
 // flush with the edge of the case
 module countersunk_screw_passthrough_m2()
 {
-	cylinder(d1=3.5, d2=2.2, h=1, center=true, $fn=30);
+	cylinder(d1=4.2, d2=2.2, h=1.2, center=true, $fn=30);
 }
 
 // a profile of a tapping hole for an m2 screw to screw into for mounting

--- a/hardware/case/case.scad
+++ b/hardware/case/case.scad
@@ -238,6 +238,20 @@ module case_top()
 // should sit flush with the board due the large the LED/sensor holes
 module case_bottom()
 {
+	// Screws in the holes to check countersinking
+	/*
+	color("red")
+	{
+		translate([0, 0, 0])
+			screw_m2();
+		translate([23, 0, 0])
+			screw_m2();
+		translate([0,72.9, 0])
+			screw_m2();
+		translate([23, 61.5, 0])
+			screw_m2();
+	}
+	*/
 	difference()
 	{
 		linear_extrude(height = 2)

--- a/hardware/case/case.scad
+++ b/hardware/case/case.scad
@@ -261,28 +261,32 @@ module case_bottom()
 		// bottom left screw hole
 		translate([0,0,0])
 		{
-			countersunk_screw_passthrough_m2();
+			translate([0,0,0.6])
+				countersunk_screw_passthrough_m2();
 			scale([1,1,2.5])
 				passthrough_screw_hole_m2();
 		}
 		// bottom right screw hole
 		translate([23,0,0])
 		{
-			countersunk_screw_passthrough_m2();
+			translate([0,0,0.6])
+				countersunk_screw_passthrough_m2();
 			scale([1,1,2.5])
 				passthrough_screw_hole_m2();
 		}
 		// top left screw hole
 		translate([0,72.9,0])
 		{
-			countersunk_screw_passthrough_m2();
+			translate([0,0,0.6])
+				countersunk_screw_passthrough_m2();
 			scale([1,1,2.5])
 				passthrough_screw_hole_m2();
 		}
 		// top right screw hole
 		translate([23,61.5,0])
 		{
-			countersunk_screw_passthrough_m2();
+			translate([0,0,0.6])
+				countersunk_screw_passthrough_m2();
 			scale([1,1,2.5])
 				passthrough_screw_hole_m2();
 		}


### PR DESCRIPTION
This PR makes the case's screw holes a little wider and sinks them all the way into the board, so that countersunk screws won't stick out of the case.