### PR TITLE
Add instructions and tooling to convert the kicad board to stl

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -19,6 +19,29 @@ If you wish to send the board off for manufacturing or creat an accurate render
 then you'll need the kicad-util tool which can be found here:
 <https://gitlab.com/dren.dk/kicad-util>
 
+# Generating a model for the case
+
+In addition to the above tools, you will also need blender <https://www.blender.org/>.
+
+## 1. Delete the faceplate
+
+The faceplate is not required for the case and will only get in the way.
+
+Using kicad 5, open up `bloodlight.pro`, then `bloodlight.kicad_pcb`.
+
+Select and drag around the entire face plate to the right and delete it.
+
+Then, click on the lines going from the main board to the faceplate and delete those, too.
+
+## 2. Export the model to vrml
+
+From the pcb viewer, do `File->export->VRML`, and ensure the output units are in mm.
+The file should be named something like bloodlight.wrl
+
+## 3. Convert the VRML to STL
+
+Run `blender --background --python blender-wrl-to-stl.py -- bloodlight.wrl`
+This will generate a board.stl in the same directory as bloodlight.wrl.
 
 # Manufacture
 

--- a/hardware/blender-wrl-to-stl.py
+++ b/hardware/blender-wrl-to-stl.py
@@ -1,0 +1,17 @@
+# usage: blender --background --python <this file> -- [input_filename]
+import sys
+import os
+import bpy
+argv = sys.argv[sys.argv.index("--") + 1:] # ignore args to blender
+
+assert argv, "No arguments passed to script"
+assert argv[0], "No filename argument passed"
+parent_dir = os.path.dirname(argv[0])
+output_path = os.path.join(parent_dir, "board.stl")
+bpy.ops.import_scene.x3d(filepath=os.path.abspath(argv[0]), axis_up="Z", axis_forward="Y")
+for obj in bpy.data.objects:
+    if obj.name in ("Camera", "Cube", "Lamp"):
+        obj.select = False
+    else:
+        obj.select = True # some versions use obj.select_set(True)
+bpy.ops.export_mesh.stl(filepath=output_path, use_selection=True)


### PR DESCRIPTION
These instructions should be sufficient to convert the kicad_pcb file into an stl readable by openscad which can be used to see how the board fits into the case.

It was suggested that I should use kicadutil to convert the board before exporting it to stl, but after deleting the faceplate, I couldn't see any difference comparing them side-to-side.

Unfortunately, I couldn't see any way to automate converting from kicad_pcb to wrl, since kicad appears to lack a command-line interface.