### PR TITLE
Fix screw sinking

### DIFF
--- a/hardware/case/case-parts.scad
+++ b/hardware/case/case-parts.scad
@@ -14,7 +14,7 @@ module screw_m2()
 // an m2 to pass through
 module passthrough_screw_hole_m2()
 {
-	cylinder(d=2.2, h=2, center=true, $fn=30);
+	cylinder(d=2.1, h=2, center=true, $fn=30);
 }
 
 // difference this at the edge of a passthrough for countersunk screws to sit
@@ -26,7 +26,7 @@ module countersunk_screw_passthrough_m2()
 		translate([0,0,-0.6])
 			cylinder(d=4.2, h=0.4, center=true, $fn=30);
 		translate([0,0,0.1])
-			cylinder(d1=4.2, d2=2.2, h=1.0, center=true, $fn=30);
+			cylinder(d1=4.2, d2=2.1, h=1.0, center=true, $fn=30);
 	}
 }
 

--- a/hardware/case/case-parts.scad
+++ b/hardware/case/case-parts.scad
@@ -3,8 +3,10 @@ module screw_m2()
 {
 	union()
 	{
+		cylinder(d=3.8, h=0.2, $fn=30);
 		cylinder(d=2, h=6, $fn=30);
-		cylinder(d1=3.8, d2=2, h=1.2, $fn=30);
+		translate([0,0,0.2])
+			cylinder(d1=3.8, d2=2, h=1.0, $fn=30);
 	}
 }
 
@@ -19,7 +21,13 @@ module passthrough_screw_hole_m2()
 // flush with the edge of the case
 module countersunk_screw_passthrough_m2()
 {
-	cylinder(d1=4.2, d2=2.2, h=1.2, center=true, $fn=30);
+	union()
+	{
+		translate([0,0,-0.6])
+			cylinder(d=4.2, h=0.4, center=true, $fn=30);
+		translate([0,0,0.1])
+			cylinder(d1=4.2, d2=2.2, h=1.0, center=true, $fn=30);
+	}
 }
 
 // a profile of a tapping hole for an m2 screw to screw into for mounting


### PR DESCRIPTION
This does three things:
* Accurately models the screw heads, so it's clearer where they fit.
* Rework the sunken screw holes so they sink all the way in.
* Make the screw holes thinner so that the screws fit tighter.